### PR TITLE
fix misalignment when horizontalJustification==FlowLayoutHorizontalJustificationLeft

### DIFF
--- a/Pod/Classes/ERJustifiedFlowLayout.m
+++ b/Pod/Classes/ERJustifiedFlowLayout.m
@@ -36,7 +36,13 @@
 				newLeftAlignedFrame.origin.x = leftMargin;
 				attributes.frame = newLeftAlignedFrame;
 			}
-			
+
+            if (leftMargin + attributes.frame.size.width + self.horizontalCellPadding > CGRectGetWidth(rect)) {
+                CGRect newLeftAlignedFrame = attributes.frame;
+                newLeftAlignedFrame.origin.x = self.sectionInset.left;
+                attributes.frame = newLeftAlignedFrame;
+            }
+            
 			leftMargin += attributes.frame.size.width + self.horizontalCellPadding;
 			
 			[newAttributesForElementsInRect addObject:attributes];


### PR DESCRIPTION
Faced the case, when I had 2 items, that covered almost all width available and next item on a next line had a wrong left offset. This fixes the problem.
